### PR TITLE
fix: Failed to download boost in all recipes

### DIFF
--- a/swig_wrappers/build_recipes/linux/Dockerfile_linux_x86_64
+++ b/swig_wrappers/build_recipes/linux/Dockerfile_linux_x86_64
@@ -23,7 +23,7 @@ ARG BZIP2_CHKSUM="67e051268d0c475ea773822f7500d0e5"
 ARG LZMA_VERSION="5.6.3"
 ARG LZMA_CHKSUM="e7f2caec3e4951673942f45cbf706797"
 ARG BOOST_VERSION="1_83_0"
-ARG BOOST_CHKSUM="6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"
+ARG BOOST_CHKSUM="6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e" 
 ARG CMAKE_VERSION="3.27.7"
 ARG CMAKE_CHKSUM="0f11cf15c7f2fa6234b9fc415c78029c"
 ARG EIGEN_VERSION="3.4.0"
@@ -155,7 +155,7 @@ RUN source ${DEVTOOLSET_PATH}/enable && make -j${BUILD_CONCURRENCY} && make -j${
 
 RUN mkdir -p ${WORK}/boost
 WORKDIR ${WORK}/boost
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/`echo ${BOOST_VERSION} | sed "s|_|.|g"`/source/boost_${BOOST_VERSION}.tar.bz2 && \
+RUN curl -L -O https://sourceforge.net/projects/boost/files/boost/1.83.0/boost_${BOOST_VERSION}.tar.bz2 && \
     [ `sha256sum boost_${BOOST_VERSION}.tar.bz2 | awk '{print $1}'` = ${BOOST_CHKSUM} ] || \
     ( >&2 echo "Failed to download boost" && exit 1 )
 RUN tar xjf boost_${BOOST_VERSION}.tar.bz2

--- a/swig_wrappers/build_recipes/macos/Ansible_playbook_macOS.yml
+++ b/swig_wrappers/build_recipes/macos/Ansible_playbook_macOS.yml
@@ -230,7 +230,7 @@
       ansible.builtin.shell: if [ ! -e boost_{{ BOOST_VERSION }}.tar.bz2 ] || \
           [ `shasum -a 256 boost_{{ BOOST_VERSION }}.tar.bz2 | awk "{print \\$1}"` != {{ BOOST_CHKSUM }} ]; then \
           rm -f boost_{{ BOOST_VERSION }}.tar.bz2; \
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/`echo {{ BOOST_VERSION }} | sed "s|_|.|g"`/source/boost_{{ BOOST_VERSION }}.tar.bz2 && \
+          curl -L -O https://sourceforge.net/projects/boost/files/boost/1.83.0/boost_${BOOST_VERSION}.tar.bz2 && \
             [ `shasum -a 256 boost_{{ BOOST_VERSION }}.tar.bz2 | awk "{print \\$1}"` = {{ BOOST_CHKSUM }} ] || \
             ( >&2 echo "Failed to download boost" && exit 1 ); \
         fi

--- a/swig_wrappers/build_recipes/windows/Dockerfile_windows
+++ b/swig_wrappers/build_recipes/windows/Dockerfile_windows
@@ -62,7 +62,7 @@ ARG BZIP2_CHKSUM="67e051268d0c475ea773822f7500d0e5"
 ARG LZMA_VERSION="5.6.3"
 ARG LZMA_CHKSUM="e7f2caec3e4951673942f45cbf706797"
 ARG BOOST_VERSION="1_83_0"
-ARG BOOST_CHKSUM="6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"
+ARG BOOST_CHKSUM="6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e" 
 ARG CMAKE_VERSION="3.27.7"
 ARG CMAKE_CHKSUM="0f11cf15c7f2fa6234b9fc415c78029c"
 ARG EIGEN_VERSION="3.4.0"
@@ -110,7 +110,7 @@ RUN make -j${BUILD_CONCURRENCY} && make -j${BUILD_CONCURRENCY} install
 
 RUN mkdir -p ${WORK}/boost
 WORKDIR ${WORK}/boost
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/`echo ${BOOST_VERSION} | sed "s|_|.|g"`/source/boost_${BOOST_VERSION}.tar.bz2 && \
+RUN curl -L -O https://sourceforge.net/projects/boost/files/boost/1.83.0/boost_${BOOST_VERSION}.tar.bz2 && \
     [ `sha256sum boost_${BOOST_VERSION}.tar.bz2 | awk '{print $1}'` = ${BOOST_CHKSUM} ] || \
     ( >&2 echo "Failed to download boost" && exit 1 )
 RUN tar xjf boost_${BOOST_VERSION}.tar.bz2


### PR DESCRIPTION
Hello.

Recently Boost page hosted on `jfrog` is down, so to fix this i changed it to a more stable (hopefully) option which is `Sourceforge`